### PR TITLE
fix: corrige estado global mutável da API, conflito revalidate/force-…

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,21 +4,11 @@ import type { NextRequest } from 'next/server';
 export function middleware(request: NextRequest) {
     const pathname = request.nextUrl.pathname;
 
-    const pathnameIsMissingLocale = ['pt-BR', 'en-US'].every(
-        (locale) => !pathname.startsWith(`/${locale}/`) && pathname !== `/${locale}`
-    );
-
-    if (pathnameIsMissingLocale) {
-        const locale = request.cookies.get('NEXT_LOCALE')?.value || 'pt-BR';
-
-        return NextResponse.redirect(
-            new URL(`/${locale}${pathname === '/' ? '' : pathname}`, request.url)
-        );
+    if (pathname === '/') {
+        return NextResponse.redirect(new URL('/movie', request.url));
     }
 }
 
 export const config = {
-    matcher: [
-        '/((?!_next).*)',
-    ],
+    matcher: ['/'],
 };

--- a/src/app/cast/[id]/page.tsx
+++ b/src/app/cast/[id]/page.tsx
@@ -24,7 +24,7 @@ export default function CastDetails() {
                 call: (signal?: AbortSignal) =>
                     castApi.findByPeople(
                         `${cast.id}?append_to_response=external_ids,movie_credits`,
-                        signal
+                        { signal, language }
                     )
             }
         ],

--- a/src/app/movie/MovieClient.tsx
+++ b/src/app/movie/MovieClient.tsx
@@ -25,10 +25,10 @@ export default function MovieClient({ initialData }: MovieClientProps) {
     ], [t]);
 
     const apiConfig = useMemo(() => ({
-        mediaCall: (route: string, page: number, signal?: AbortSignal) =>
-            movieApi.listMovie(`${route}?page=${page}`, signal),
-        genreCall: (signal?: AbortSignal) =>
-            genreApi.findAllGenre("/movie/list", signal)
+        mediaCall: (route: string, page: number, options?: { signal?: AbortSignal; language?: string }) =>
+            movieApi.listMovie(`${route}?page=${page}`, options),
+        genreCall: (options?: { signal?: AbortSignal; language?: string }) =>
+            genreApi.findAllGenre("/movie/list", options)
     }), []);
 
     return (

--- a/src/app/movie/page.tsx
+++ b/src/app/movie/page.tsx
@@ -34,5 +34,4 @@ export default async function PageMovies() {
     );
 }
 
-export const revalidate = 3600;
 export const dynamic = 'force-dynamic';

--- a/src/app/tvShows/TvShowsClient.tsx
+++ b/src/app/tvShows/TvShowsClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useMemo } from "react";
 import { IGenre, IResponse, IListTvShows } from "../../shared/interfaces";
-import { genreApi, tvShows } from "../../shared/api/api";
+import { genreApi, tvShowsApi } from "../../shared/api/api";
 import { useTranslation } from "@/shared/hooks/useTranslation";
 import MediaListClient from "@/shared/components/mediaList/MediaListClient";
 
@@ -24,10 +24,10 @@ export default function TvShowsClient({ initialData }: TvShowsClientProps) {
     ], [t]);
 
     const apiConfig = useMemo(() => ({
-        mediaCall: (route: string, page: number, signal?: AbortSignal) =>
-            tvShows.listTvShows(`${route}?page=${page}`, signal),
-        genreCall: (signal?: AbortSignal) =>
-            genreApi.findAllGenre("/tv/list", signal)
+        mediaCall: (route: string, page: number, options?: { signal?: AbortSignal; language?: string }) =>
+            tvShowsApi.listTvShows(`${route}?page=${page}`, options),
+        genreCall: (options?: { signal?: AbortSignal; language?: string }) =>
+            genreApi.findAllGenre("/tv/list", options)
     }), []);
 
     return (

--- a/src/app/tvShows/[id]/page.tsx
+++ b/src/app/tvShows/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { tvShows } from "@/shared/api/api";
+import { tvShowsApi } from "@/shared/api/api";
 import { Layout } from "@/shared/components/layoutComponent";
 import { Suspense, lazy } from "react";
 import { formatDate, formatGenres } from "@/shared/utils";
@@ -10,7 +10,7 @@ const ImageMovie = lazy(() => import("@/shared/components/imageMovie/imageMovie"
 
 async function getServerSideTvShowData(id: string) {
     try {
-        const details = await tvShows.findByTvShow(`${id}?append_to_response=credits,videos`);
+        const details = await tvShowsApi.findByTvShow(`${id}?append_to_response=credits,videos`);
         return { details };
     } catch (error) {
         console.error("Error fetching TV show details:", error);

--- a/src/app/tvShows/page.tsx
+++ b/src/app/tvShows/page.tsx
@@ -1,12 +1,12 @@
 import { Suspense } from "react";
 import TvShowsClient from "./TvShowsClient";
-import { genreApi, tvShows } from "../../shared/api/api";
+import { genreApi, tvShowsApi } from "../../shared/api/api";
 
 async function getServerSideData(route: string = "/airing_today", page: number = 1) {
     try {
         const [genresResponse, seriesResponse] = await Promise.all([
             genreApi.findAllGenre("/tv/list"),
-            tvShows.listTvShows(`${route}?page=${page}`)
+            tvShowsApi.listTvShows(`${route}?page=${page}`)
         ]);
 
         return {
@@ -32,5 +32,4 @@ export default async function PageTvShows() {
     );
 }
 
-export const revalidate = 3600;
 export const dynamic = 'force-dynamic';

--- a/src/shared/api/api.ts
+++ b/src/shared/api/api.ts
@@ -19,6 +19,8 @@ import {
     safeValidateImageData
 } from "@/shared/validators/validators";
 
+const DEFAULT_LANGUAGE = "pt-BR";
+
 const createApiInstance = (url: string): AxiosInstance => {
     return axios.create({
         baseURL: process.env.NEXT_PUBLIC_URL + url,
@@ -45,32 +47,24 @@ const logValidationWarning = (context: string, errors: unknown) => {
     }
 };
 
+type RequestOptions = {
+    signal?: AbortSignal;
+    language?: string;
+};
+
 export class Api {
     private api: AxiosInstance;
 
-    private url: string;
-
-    private language: string = "pt-BR";
-
     constructor(url: string = "/movie") {
         this.api = createApiInstance(url);
-        this.url = url;
     }
 
-    setUrl(newUrl: string): void {
-        this.url = newUrl;
-        this.api = createApiInstance(newUrl);
-    }
-
-    setLanguage(language: string): void {
-        this.language = language;
-    }
-
-    private async getRequest<T>(endpoint: string, signal?: AbortSignal): Promise<T> {
+    private async getRequest<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+        const { signal, language = DEFAULT_LANGUAGE } = options;
         try {
             const { data } = await this.api.get(endpoint, {
                 params: {
-                    language: endpoint.includes("images") ? "" : this.language
+                    language: endpoint.includes("images") ? "" : language
                 },
                 signal
             });
@@ -81,8 +75,8 @@ export class Api {
         }
     }
 
-    async findByMovie(id: string, signal?: AbortSignal): Promise<IMovie> {
-        const data = await this.getRequest<IMovie>(id, signal);
+    async findByMovie(id: string, options: RequestOptions = {}): Promise<IMovie> {
+        const data = await this.getRequest<IMovie>(id, options);
         const result = safeValidateMovieDetails(data);
         if (!result.success) {
             logValidationWarning(`findByMovie(${id})`, result.error.issues);
@@ -90,8 +84,8 @@ export class Api {
         return data;
     }
 
-    async findByTvShow(id: string, signal?: AbortSignal): Promise<ITvShow> {
-        const data = await this.getRequest<ITvShow>(id, signal);
+    async findByTvShow(id: string, options: RequestOptions = {}): Promise<ITvShow> {
+        const data = await this.getRequest<ITvShow>(id, options);
         const result = safeValidateTVShowDetails(data);
         if (!result.success) {
             logValidationWarning(`findByTvShow(${id})`, result.error.issues);
@@ -99,8 +93,8 @@ export class Api {
         return data;
     }
 
-    async listMovie(url: string, signal?: AbortSignal): Promise<IResponse<IListMovie[]>> {
-        const data = await this.getRequest<IResponse<IListMovie[]>>(url, signal);
+    async listMovie(url: string, options: RequestOptions = {}): Promise<IResponse<IListMovie[]>> {
+        const data = await this.getRequest<IResponse<IListMovie[]>>(url, options);
         const result = safeValidateMovieList(data);
         if (!result.success) {
             logValidationWarning(`listMovie(${url})`, result.error.issues);
@@ -108,8 +102,8 @@ export class Api {
         return data;
     }
 
-    async listTvShows(url: string, signal?: AbortSignal): Promise<IResponse<IListTvShows[]>> {
-        const data = await this.getRequest<IResponse<IListTvShows[]>>(url, signal);
+    async listTvShows(url: string, options: RequestOptions = {}): Promise<IResponse<IListTvShows[]>> {
+        const data = await this.getRequest<IResponse<IListTvShows[]>>(url, options);
         const result = safeValidateTVShowList(data);
         if (!result.success) {
             logValidationWarning(`listTvShows(${url})`, result.error.issues);
@@ -117,8 +111,8 @@ export class Api {
         return data;
     }
 
-    async findByPeople(url: string, signal?: AbortSignal): Promise<IActorDetails> {
-        const data = await this.getRequest<IActorDetails>(url, signal);
+    async findByPeople(url: string, options: RequestOptions = {}): Promise<IActorDetails> {
+        const data = await this.getRequest<IActorDetails>(url, options);
         const result = safeValidateActorDetails(data);
         if (!result.success) {
             logValidationWarning(`findByPeople(${url})`, result.error.issues);
@@ -126,8 +120,8 @@ export class Api {
         return data;
     }
 
-    async findAllGenre(url: string, signal?: AbortSignal): Promise<{ genres: IGenre[] }> {
-        const data = await this.getRequest<{ genres: IGenre[] }>(url, signal);
+    async findAllGenre(url: string, options: RequestOptions = {}): Promise<{ genres: IGenre[] }> {
+        const data = await this.getRequest<{ genres: IGenre[] }>(url, options);
         const result = safeValidateGenreList(data);
         if (!result.success) {
             logValidationWarning(`findAllGenre(${url})`, result.error.issues);
@@ -135,8 +129,8 @@ export class Api {
         return data;
     }
 
-    async findImagesMovie(id: string, url: string, signal?: AbortSignal): Promise<IImage> {
-        const data = await this.getRequest<IImage>(`${id}/${url}`, signal);
+    async findImagesMovie(id: string, url: string, options: RequestOptions = {}): Promise<IImage> {
+        const data = await this.getRequest<IImage>(`${id}/${url}`, options);
         const result = safeValidateImageData(data);
         if (!result.success) {
             logValidationWarning(`findImagesMovie(${id}/${url})`, result.error.issues);
@@ -148,5 +142,4 @@ export class Api {
 export const movieApi = new Api();
 export const genreApi = new Api("/genre");
 export const castApi = new Api("/person");
-export const imageApi = new Api();
-export const tvShows = new Api("/tv");
+export const tvShowsApi = new Api("/tv");

--- a/src/shared/components/imageMovie/imageMovie.tsx
+++ b/src/shared/components/imageMovie/imageMovie.tsx
@@ -1,8 +1,8 @@
 'use client'
 import { useMemo } from "react";
 import "./imageMovie.style.scss";
-import { imageApi } from "../../api/api";
-import { useFetchData } from "../../hook/useFetchData";
+import { Api } from "../../api/api";
+import { useFetchData } from "../../hooks/useFetchData";
 import { IImage } from "../../interfaces";
 import { useAppContext } from "@/shared/context/context";
 import { useTranslation } from "@/shared/hooks/useTranslation";
@@ -15,18 +15,19 @@ export const ImageMovie = ({
     param: string;
     urlApi: string;
 }) => {
-    imageApi.setUrl(urlApi);
     const { language } = useAppContext();
     const { t } = useTranslation('common');
+
+    const api = useMemo(() => new Api(urlApi), [urlApi]);
 
     const apiCalls = useMemo(
         () => [
             {
                 key: "posters",
-                call: (signal?: AbortSignal) => imageApi.findImagesMovie(param, "images", signal)
+                call: (signal?: AbortSignal) => api.findImagesMovie(param, "images", { signal, language })
             }
         ],
-        [param, language]
+        [param, language, api]
     );
 
     const { data } = useFetchData<{ posters: IImage }>(apiCalls);

--- a/src/shared/components/mediaList/MediaListClient.tsx
+++ b/src/shared/components/mediaList/MediaListClient.tsx
@@ -16,9 +16,14 @@ type ButtonConfig = {
     route: string;
 };
 
+type RequestOptions = {
+    signal?: AbortSignal;
+    language?: string;
+};
+
 type ApiCallConfig = {
-    mediaCall: (route: string, page: number, signal?: AbortSignal) => Promise<IResponse<MediaItem[]>>;
-    genreCall: (signal?: AbortSignal) => Promise<{ genres: IGenre[] }>;
+    mediaCall: (route: string, page: number, options?: RequestOptions) => Promise<IResponse<MediaItem[]>>;
+    genreCall: (options?: RequestOptions) => Promise<{ genres: IGenre[] }>;
 };
 
 type MediaListData = {
@@ -57,11 +62,11 @@ export default function MediaListClient({
         () => [
             {
                 key: "media",
-                call: (signal?: AbortSignal) => apiConfig.mediaCall(activeRoute, page, signal)
+                call: (signal?: AbortSignal) => apiConfig.mediaCall(activeRoute, page, { signal, language })
             },
             {
                 key: "genres",
-                call: (signal?: AbortSignal) => apiConfig.genreCall(signal)
+                call: (signal?: AbortSignal) => apiConfig.genreCall({ signal, language })
             }
         ],
         [activeRoute, page, language, apiConfig]

--- a/src/shared/context/context.tsx
+++ b/src/shared/context/context.tsx
@@ -6,7 +6,6 @@ import {
     useEffect,
     useState
 } from "react";
-import { castApi, genreApi, imageApi, movieApi, tvShows } from "../api/api";
 import i18n from '../../i18n';
 
 type Props = {
@@ -38,12 +37,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
         sessionStorage.setItem("language", value);
         setLanguage(value);
         i18n.changeLanguage(value);
-
-        movieApi.setLanguage(value);
-        genreApi.setLanguage(value);
-        castApi.setLanguage(value);
-        imageApi.setLanguage(value);
-        tvShows.setLanguage(value);
     };
 
     if (!isI18nReady) {


### PR DESCRIPTION
…dynamic e middleware quebrado

- Refatora API para receber language como parâmetro (RequestOptions) ao invés de mutar estado singleton
- Remove setLanguage() e setUrl() da classe Api (unsafe em SSR)
- Remove imageApi singleton, ImageMovie agora cria instância própria por urlApi
- Remove revalidate conflitante com force-dynamic nas pages
- Substitui middleware de locale (redirecionava pra rotas inexistentes) por redirect simples / → /movie
- Renomeia export tvShows → tvShowsApi para clareza
- Context não mais chama api.setLanguage(), apenas gerencia estado de i18n