### PR TITLE
fix: corrige desalinhamento do nome do elenco com a foto no slider

### DIFF
--- a/src/components/sliderActors/sliderActors.style.scss
+++ b/src/components/sliderActors/sliderActors.style.scss
@@ -18,10 +18,16 @@
             .cast {
                 margin-top: 2rem;
                 justify-items: center;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
 
                 a {
                     img {
                         border-radius: .6rem;
+                        width: 200px;
+                        height: 300px;
+                        object-fit: cover;
                     }
                 }
 


### PR DESCRIPTION
- Adiciona altura fixa (300px) e object-fit: cover nas imagens do elenco
- Aplica flexbox column no card .cast para alinhar foto e texto verticalmente
- Nomes e personagens agora ficam na mesma linha independente do tamanho da foto original