### PR TITLE
feat: adiciona proxy API, melhora tipagem do useFetchData e cria load…

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,4 @@
-﻿const path = require('path');
-
-const nextConfig = {
+﻿const nextConfig = {
   images: {
     remotePatterns: [
       {

--- a/src/app/api/tmdb/[...path]/route.ts
+++ b/src/app/api/tmdb/[...path]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const TMDB_BASE_URL = process.env.TMDB_BASE_URL || "https://api.themoviedb.org/3";
+const TMDB_TOKEN = process.env.TMDB_READ_API_TOKEN;
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ path: string[] }> }
+) {
+    const { path } = await params;
+    const endpoint = "/" + path.join("/");
+    const searchParams = request.nextUrl.searchParams;
+
+    const url = new URL(endpoint, TMDB_BASE_URL);
+    searchParams.forEach((value, key) => {
+        url.searchParams.set(key, value);
+    });
+
+    try {
+        const response = await fetch(url.toString(), {
+            headers: {
+                Accept: "application/json",
+                Authorization: `Bearer ${TMDB_TOKEN}`
+            },
+            signal: AbortSignal.timeout(10000)
+        });
+
+        if (!response.ok) {
+            return NextResponse.json(
+                { message: `TMDB API error: ${response.statusText}` },
+                { status: response.status }
+            );
+        }
+
+        const data = await response.json();
+        return NextResponse.json(data);
+    } catch (error) {
+        console.error("[TMDB Proxy]", error);
+        return NextResponse.json(
+            { message: "Failed to fetch from TMDB" },
+            { status: 502 }
+        );
+    }
+}

--- a/src/app/cast/[id]/loading.tsx
+++ b/src/app/cast/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { SkeletonDetailsActors } from "@/components/skeletonLoading";
+
+export default function Loading() {
+    return <SkeletonDetailsActors />;
+}

--- a/src/app/movie/[id]/loading.tsx
+++ b/src/app/movie/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { SkeletonDetails } from "@/components/skeletonLoading";
+
+export default function Loading() {
+    return <SkeletonDetails />;
+}

--- a/src/app/movie/loading.tsx
+++ b/src/app/movie/loading.tsx
@@ -1,0 +1,17 @@
+import SkeletonBanner from "@/components/skeletonLoading/skeletonBanner";
+
+export default function Loading() {
+    return (
+        <div className="container box">
+            <section className="content-list">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-8" style={{ paddingTop: '4rem' }}>
+                    {Array(10)
+                        .fill(0)
+                        .map((_, i) => (
+                            <SkeletonBanner key={i} />
+                        ))}
+                </div>
+            </section>
+        </div>
+    );
+}

--- a/src/app/movie/page.tsx
+++ b/src/app/movie/page.tsx
@@ -1,5 +1,4 @@
 import { genreApi, movieApi } from "@/lib/api";
-import { Suspense } from "react";
 import MovieClient from "./MovieClient";
 
 async function getServerSideData(route: string = "/now_playing", page: number = 1) {
@@ -27,9 +26,7 @@ export default async function PageMovies() {
 
     return (
         <main>
-            <Suspense fallback={<div>Loading...</div>}>
-                <MovieClient initialData={initialData} />
-            </Suspense>
+            <MovieClient initialData={initialData} />
         </main>
     );
 }

--- a/src/app/tv-shows/[id]/loading.tsx
+++ b/src/app/tv-shows/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { SkeletonDetails } from "@/components/skeletonLoading";
+
+export default function Loading() {
+    return <SkeletonDetails />;
+}

--- a/src/app/tv-shows/loading.tsx
+++ b/src/app/tv-shows/loading.tsx
@@ -1,0 +1,17 @@
+import SkeletonBanner from "@/components/skeletonLoading/skeletonBanner";
+
+export default function Loading() {
+    return (
+        <div className="container box">
+            <section className="content-list">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-8" style={{ paddingTop: '4rem' }}>
+                    {Array(10)
+                        .fill(0)
+                        .map((_, i) => (
+                            <SkeletonBanner key={i} />
+                        ))}
+                </div>
+            </section>
+        </div>
+    );
+}

--- a/src/app/tv-shows/page.tsx
+++ b/src/app/tv-shows/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from "react";
 import TvShowsClient from "./TvShowsClient";
 import { genreApi, tvShowsApi } from "@/lib/api";
 
@@ -25,11 +24,7 @@ async function getServerSideData(route: string = "/airing_today", page: number =
 export default async function PageTvShows() {
     const initialData = await getServerSideData();
 
-    return (
-        <Suspense fallback={<div>Loading...</div>}>
-            <TvShowsClient initialData={initialData} />
-        </Suspense>
-    );
+    return <TvShowsClient initialData={initialData} />;
 }
 
 export const dynamic = 'force-dynamic';

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { IListMovie, IListTvShows, IResponse } from "@/types";
+import { IResponse } from "@/types";
 import { useTranslation } from "@/hooks/useTranslation";
 
 type Props = {
-    dataPage?: IResponse<IListMovie[] | IListTvShows[]>;
+    dataPage?: IResponse<unknown[]>;
     totalItemShow?: number;
     onSet: (item: number) => void;
     onPageChange: (value: number) => void;

--- a/src/components/skeletonLoading/skeletonBanner.tsx
+++ b/src/components/skeletonLoading/skeletonBanner.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Skeleton from "react-loading-skeleton";
 
 export default function SkeletonBanner() {

--- a/src/components/skeletonLoading/skeletonDetails.tsx
+++ b/src/components/skeletonLoading/skeletonDetails.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Skeleton from "react-loading-skeleton";
 import { Layout } from "../layoutComponent";
 import SkeletonSlider from "./skeletonSlider";

--- a/src/components/skeletonLoading/skeletonDetailsActors.tsx
+++ b/src/components/skeletonLoading/skeletonDetailsActors.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Layout } from "../layoutComponent";
 import Skeleton from "react-loading-skeleton";
 

--- a/src/components/skeletonLoading/skeletonImages.tsx
+++ b/src/components/skeletonLoading/skeletonImages.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Skeleton from "react-loading-skeleton";
 
 export default function SkeletonImages() {

--- a/src/components/skeletonLoading/skeletonSlider.tsx
+++ b/src/components/skeletonLoading/skeletonSlider.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Skeleton from "react-loading-skeleton";
 import Slider from "react-slick";
 

--- a/src/hooks/useFetchData.ts
+++ b/src/hooks/useFetchData.ts
@@ -1,18 +1,18 @@
 "use client";
 import { useEffect, useState, useRef } from "react";
 
-type Data = {
-    [key: string]: any;
+type ApiCall<K extends string, V> = {
+    key: K;
+    call: (signal?: AbortSignal) => Promise<V>;
 };
 
-type ApiCall<T> = {
-    key: string;
-    call: (signal?: AbortSignal) => Promise<T>;
-};
+type ApiCallEntry = ApiCall<string, unknown>;
 
-export const useFetchData = <T extends Data>(apiCalls: ApiCall<any>[]) => {
+export const useFetchData = <T extends Record<string, unknown>>(
+    apiCalls: { [K in keyof T]: ApiCall<K & string, T[K]> }[keyof T][]
+) => {
     const [data, setData] = useState<T | null>(null);
-    const [loading, setLoading] = useState<boolean>(false);
+    const [loading, setLoading] = useState<boolean>(true);
     const abortControllerRef = useRef<AbortController | null>(null);
 
     useEffect(() => {
@@ -26,12 +26,13 @@ export const useFetchData = <T extends Data>(apiCalls: ApiCall<any>[]) => {
         const fetchData = async () => {
             setLoading(true);
             try {
+                const calls = apiCalls as ApiCallEntry[];
                 const results = await Promise.all(
-                    apiCalls.map((api) => api.call(abortController.signal))
+                    calls.map((api) => api.call(abortController.signal))
                 );
-                const newData: Data = {};
+                const newData = {} as Record<string, unknown>;
                 results.forEach((result, index) => {
-                    newData[apiCalls[index].key] = result;
+                    newData[calls[index].key] = result;
                 });
                 setData(newData as T);
             } catch (error) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -21,14 +21,29 @@ import {
 
 const DEFAULT_LANGUAGE = "pt-BR";
 
+const getBaseUrl = (url: string) => {
+    if (typeof window !== "undefined") {
+        // Client-side: usa o proxy route handler pra não expor o token
+        return "/api/tmdb" + url;
+    }
+    // Server-side: chama a TMDB diretamente (token seguro no servidor)
+    return (process.env.TMDB_BASE_URL || "https://api.themoviedb.org/3") + url;
+};
+
+const getHeaders = () => {
+    if (typeof window !== "undefined") {
+        return { Accept: "application/json" };
+    }
+    return {
+        Accept: "application/json",
+        Authorization: `Bearer ${process.env.TMDB_READ_API_TOKEN}`
+    };
+};
+
 const createApiInstance = (url: string): AxiosInstance => {
     return axios.create({
-        baseURL: process.env.NEXT_PUBLIC_URL + url,
-
-        headers: {
-            Accept: "application/json",
-            Authorization: `Bearer ${process.env.NEXT_PUBLIC_TOKEN_READ_API}`
-        }
+        baseURL: getBaseUrl(url),
+        headers: getHeaders()
     });
 };
 
@@ -47,7 +62,7 @@ const logValidationWarning = (context: string, errors: unknown) => {
     }
 };
 
-type RequestOptions = {
+export type RequestOptions = {
     signal?: AbortSignal;
     language?: string;
 };


### PR DESCRIPTION
…ing.tsx por rota

- Cria Route Handler /api/tmdb/[...path] como proxy para TMDB (esconde token do client)
- API usa proxy no client e chama TMDB diretamente no server (sem overhead)
- Remove NEXT_PUBLIC_TOKEN_READ_API e NEXT_PUBLIC_URL (agora usa TMDB_READ_API_TOKEN server-only)
- Melhora tipagem do useFetchData com generics mais restritos (remove ApiCall<any>)
- Cria loading.tsx com skeletons para movie, tv-shows, movie/[id], tv-shows/[id] e cast/[id]
- Remove Suspense inline das pages (Next.js loading.tsx cuida automaticamente)
- Adiciona 'use client' nos skeleton components (react-loading-skeleton é client-only)
- Corrige tipo do Pagination para aceitar IResponse<unknown[]> (resolve erro de build)
- Remove import não utilizado de path no next.config.js